### PR TITLE
upgrade admin-app to Vuetify 4.0.6

### DIFF
--- a/admin-app/package-lock.json
+++ b/admin-app/package-lock.json
@@ -15,7 +15,7 @@
         "vue-echarts": "^7.0.3",
         "vue-markdown-render": "^2.3.0",
         "vue-router": "^4.6.4",
-        "vuetify": "^3.7.14"
+        "vuetify": "4.0.6"
       },
       "devDependencies": {
         "@mdi/js": "^7.4.47",
@@ -8764,9 +8764,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.12.3",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.12.3.tgz",
-      "integrity": "sha512-7QzgftMu8OYKRz/jr2yntPEJ7WFmAzMn8jyeUcW7gz539MjQbDF3UrqZXW3aWi458UVJW9WWvzQn9x5B75Aijw==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.0.6.tgz",
+      "integrity": "sha512-a4kasYa3SuFI5IOG/0Fx04M4TWeef5mCdTTKFlaxt86oz16RMQ/DJ3BynlOnIdUODt7NxYIkdLYud070/vVEUQ==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/admin-app/package.json
+++ b/admin-app/package.json
@@ -24,7 +24,7 @@
     "vue-echarts": "^7.0.3",
     "vue-markdown-render": "^2.3.0",
     "vue-router": "^4.6.4",
-    "vuetify": "^3.7.14"
+    "vuetify": "4.0.6"
   },
   "devDependencies": {
     "@mdi/js": "^7.4.47",

--- a/admin-app/pnpm-lock.yaml
+++ b/admin-app/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^4.6.4
         version: 4.6.4(vue@3.5.30(typescript@5.9.3))
       vuetify:
-        specifier: ^3.7.14
-        version: 3.12.3(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.30(typescript@5.9.3))
+        specifier: 4.0.6
+        version: 4.0.6(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.30(typescript@5.9.3))
     devDependencies:
       '@mdi/js':
         specifier: ^7.4.47
@@ -113,7 +113,7 @@ importers:
         version: 0.6.1(vite@6.4.1(@types/node@22.19.15)(sass-embedded@1.98.0)(sass@1.98.0)(yaml@2.8.3))(vue-router@4.6.4(vue@3.5.30(typescript@5.9.3)))
       vite-plugin-vuetify:
         specifier: ^2.1.3
-        version: 2.1.3(vite@6.4.1(@types/node@22.19.15)(sass-embedded@1.98.0)(sass@1.98.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))(vuetify@3.12.3)
+        version: 2.1.3(vite@6.4.1(@types/node@22.19.15)(sass-embedded@1.98.0)(sass@1.98.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))(vuetify@4.0.6)
       vitest:
         specifier: ^4.1.0
         version: 4.1.0(@types/node@22.19.15)(jsdom@26.1.0)(vite@6.4.1(@types/node@22.19.15)(sass-embedded@1.98.0)(sass@1.98.0)(yaml@2.8.3))
@@ -2764,8 +2764,8 @@ packages:
       typescript:
         optional: true
 
-  vuetify@3.12.3:
-    resolution: {integrity: sha512-7QzgftMu8OYKRz/jr2yntPEJ7WFmAzMn8jyeUcW7gz539MjQbDF3UrqZXW3aWi458UVJW9WWvzQn9x5B75Aijw==}
+  vuetify@4.0.6:
+    resolution: {integrity: sha512-a4kasYa3SuFI5IOG/0Fx04M4TWeef5mCdTTKFlaxt86oz16RMQ/DJ3BynlOnIdUODt7NxYIkdLYud070/vVEUQ==}
     peerDependencies:
       typescript: '>=4.7'
       vite-plugin-vuetify: '>=2.1.0'
@@ -3743,11 +3743,11 @@ snapshots:
       typescript: 5.9.3
       vue: 3.5.30(typescript@5.9.3)
 
-  '@vuetify/loader-shared@2.1.2(vue@3.5.30(typescript@5.9.3))(vuetify@3.12.3)':
+  '@vuetify/loader-shared@2.1.2(vue@3.5.30(typescript@5.9.3))(vuetify@4.0.6)':
     dependencies:
       upath: 2.0.1
       vue: 3.5.30(typescript@5.9.3)
-      vuetify: 3.12.3(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.30(typescript@5.9.3))
+      vuetify: 4.0.6(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.30(typescript@5.9.3))
 
   '@vueuse/core@14.2.1(vue@3.5.30(typescript@5.9.3))':
     dependencies:
@@ -5396,14 +5396,14 @@ snapshots:
       vite: 6.4.1(@types/node@22.19.15)(sass-embedded@1.98.0)(sass@1.98.0)(yaml@2.8.3)
       vue-router: 4.6.4(vue@3.5.30(typescript@5.9.3))
 
-  vite-plugin-vuetify@2.1.3(vite@6.4.1(@types/node@22.19.15)(sass-embedded@1.98.0)(sass@1.98.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))(vuetify@3.12.3):
+  vite-plugin-vuetify@2.1.3(vite@6.4.1(@types/node@22.19.15)(sass-embedded@1.98.0)(sass@1.98.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))(vuetify@4.0.6):
     dependencies:
-      '@vuetify/loader-shared': 2.1.2(vue@3.5.30(typescript@5.9.3))(vuetify@3.12.3)
+      '@vuetify/loader-shared': 2.1.2(vue@3.5.30(typescript@5.9.3))(vuetify@4.0.6)
       debug: 4.4.3
       upath: 2.0.1
       vite: 6.4.1(@types/node@22.19.15)(sass-embedded@1.98.0)(sass@1.98.0)(yaml@2.8.3)
       vue: 3.5.30(typescript@5.9.3)
-      vuetify: 3.12.3(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.30(typescript@5.9.3))
+      vuetify: 4.0.6(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.30(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -5506,12 +5506,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  vuetify@3.12.3(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.30(typescript@5.9.3)):
+  vuetify@4.0.6(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       vue: 3.5.30(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
-      vite-plugin-vuetify: 2.1.3(vite@6.4.1(@types/node@22.19.15)(sass-embedded@1.98.0)(sass@1.98.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))(vuetify@3.12.3)
+      vite-plugin-vuetify: 2.1.3(vite@6.4.1(@types/node@22.19.15)(sass-embedded@1.98.0)(sass@1.98.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))(vuetify@4.0.6)
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/admin-app/src/components.d.ts
+++ b/admin-app/src/components.d.ts
@@ -11,7 +11,6 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
-    Agenda: typeof import('./components/admin/agenda.vue')['default']
     AgendaEditor: typeof import('./components/admin/agenda-editor.vue')['default']
     AppBar: typeof import('./components/layout/AppBar.vue')['default']
     AppBarNoLinks: typeof import('./components/layout/AppBarNoLinks.vue')['default']
@@ -27,7 +26,6 @@ declare module 'vue' {
     ChartSubmissionTypes: typeof import('./components/demo-charts/ChartSubmissionTypes.vue')['default']
     ChartUserTypes: typeof import('./components/demo-charts/ChartUserTypes.vue')['default']
     DialogConfirm: typeof import('./components/DialogConfirm.vue')['default']
-    Presentation: typeof import('./components/homepage/Presentation.vue')['default']
     Rating: typeof import('./components/homepage/rating.vue')['default']
     RouterWrapper: typeof import('./components/layout/RouterWrapper.vue')['default']
     StatsCard: typeof import('./components/StatsCard.vue')['default']

--- a/admin-app/src/pages/vote-for-papers.vue
+++ b/admin-app/src/pages/vote-for-papers.vue
@@ -312,7 +312,6 @@ async function vote(vote: InlineVote, value: number) {
       v-model="snackbar"
       :timeout="snackbarTimeout"
       color="info"
-      multi-line
     >
       Available shortcuts:
       <pre>

--- a/admin-app/src/plugins/vuetify.ts
+++ b/admin-app/src/plugins/vuetify.ts
@@ -2,7 +2,7 @@ import 'vuetify/styles'
 import { createVuetify, type IconSet, type IconProps } from 'vuetify'
 import { aliases, mdi } from 'vuetify/iconsets/mdi-svg'
 import { md3 } from 'vuetify/blueprints'
-import type { VDataTable } from 'vuetify/lib/components/index.mjs'
+import type { VDataTable } from 'vuetify/components'
 export type DataTableHeaders = InstanceType<
   typeof VDataTable
 >['$props']['headers']


### PR DESCRIPTION
- bump vuetify from ^3.7.14 to 4.0.6
- fix VDataTable type import: vuetify/lib/components/index.mjs → vuetify/components
- remove deprecated multi-line prop from v-snackbar